### PR TITLE
[github] Add CODEOWNER file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default oweners for everything in the repo. (integration, infra/tool files)
+* @myungjoo @jijoongmoon @again4you @jaeyun-jung @anyj0527 @gichan-jang


### PR DESCRIPTION
Add code owners for the edge repo. Define specified owner later.

Signed-off-by: gichan <gichan2.jang@samsung.com>