### PR TITLE
[MQTT] topic in broker handle

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-common.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-common.c
@@ -72,6 +72,27 @@ nns_edge_parse_host_string (const char *host_str, char **host, int *port)
 }
 
 /**
+ * @brief Parse string and get port number. Return negative value when failed to get port number.
+ */
+int
+nns_edge_parse_port_number (const char *port_str)
+{
+  int port;
+
+  if (!port_str)
+    return -1;
+
+  port = (int) strtoll (port_str, NULL, 10);
+
+  if (port <= 0 || port > 65535) {
+    nns_edge_loge ("Invalid port number %d.", port);
+    port = -1;
+  }
+
+  return port;
+}
+
+/**
  * @brief Free allocated memory.
  */
 void

--- a/src/libnnstreamer-edge/nnstreamer-edge-common.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-common.h
@@ -179,6 +179,11 @@ char *nns_edge_get_host_string (const char *host, const int port);
 void nns_edge_parse_host_string (const char *host_str, char **host, int *port);
 
 /**
+ * @brief Parse string and get port number. Return negative value when failed to get port number.
+ */
+int nns_edge_parse_port_number (const char *port_str);
+
+/**
  * @brief Free allocated memory.
  */
 void nns_edge_free (void *data);

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -1520,10 +1520,9 @@ nns_edge_set_info (nns_edge_h edge_h, const char *key, const char *value)
     SAFE_FREE (eh->host);
     eh->host = nns_edge_strdup (value);
   } else if (0 == strcasecmp (key, "PORT")) {
-    int port = (int) strtoll (value, NULL, 10);
+    int port = nns_edge_parse_port_number (value);
 
-    if (port <= 0 || port > 65535) {
-      nns_edge_loge ("Invalid port number %d.", port);
+    if (port < 0) {
       ret = NNS_EDGE_ERROR_INVALID_PARAMETER;
     } else {
       eh->port = port;
@@ -1533,10 +1532,9 @@ nns_edge_set_info (nns_edge_h edge_h, const char *key, const char *value)
     SAFE_FREE (eh->dest_host);
     eh->dest_host = nns_edge_strdup (value);
   } else if (0 == strcasecmp (key, "DEST_PORT")) {
-    int port = (int) strtoll (value, NULL, 10);
+    int port = nns_edge_parse_port_number (value);
 
-    if (port <= 0 || port > 65535) {
-      nns_edge_loge ("Invalid port number %d.", port);
+    if (port < 0) {
       ret = NNS_EDGE_ERROR_INVALID_PARAMETER;
     } else {
       eh->dest_port = port;

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.h
@@ -57,7 +57,7 @@ typedef struct {
  * @brief Connect to MQTT.
  * @note This is internal function for MQTT broker. You should call this with edge-handle lock.
  */
-int nns_edge_mqtt_connect (nns_edge_h edge_h);
+int nns_edge_mqtt_connect (nns_edge_h edge_h, const char *topic);
 
 /**
  * @brief Close the connection to MQTT.
@@ -101,7 +101,7 @@ int nns_edge_mqtt_get_message (nns_edge_h edge_h, char **msg);
 #define nns_edge_mqtt_close(...) (NNS_EDGE_ERROR_NOT_SUPPORTED)
 #define nns_edge_mqtt_publish(...) (NNS_EDGE_ERROR_NOT_SUPPORTED)
 #define nns_edge_mqtt_subscribe(...) (NNS_EDGE_ERROR_NOT_SUPPORTED)
-#define nns_edge_mqtt_is_connected(...) (NNS_EDGE_ERROR_NOT_SUPPORTED)
+#define nns_edge_mqtt_is_connected(...) (false)
 #define nns_edge_mqtt_get_message(...) (NNS_EDGE_ERROR_NOT_SUPPORTED)
 #endif
 


### PR DESCRIPTION
1. Do not replace topic string in edge handle (set topic in mqtt-handle).
2. Use util function to get/parse host string.
3. Fix res leak case when mqtt connection is failed.
4. Code clean, remove unnecessary conversion after allocating new memory for mqtt-handle.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
