### PR TITLE
[Build/Test] add mosquitto to run test

### DIFF
--- a/packaging/nnstreamer-edge.spec
+++ b/packaging/nnstreamer-edge.spec
@@ -37,6 +37,7 @@ BuildRequires:  aitt-devel
 %if 0%{?unit_test}
 BuildRequires:  gtest-devel
 BuildRequires:  procps
+BuildRequires:  mosquitto
 
 %if 0%{?testcoverage}
 BuildRequires:	lcov


### PR DESCRIPTION
Clearly define build-require to mosquitto, to run unittest using mqtt broker.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>