### PR TITLE
[packaging] Exclude Aitt related files when aitt_support is not set.

### DIFF
--- a/packaging/nnstreamer-edge.spec
+++ b/packaging/nnstreamer-edge.spec
@@ -112,7 +112,10 @@ popd
 
 %if 0%{?unit_test}
 LD_LIBRARY_PATH=./src bash %{test_script} ./tests/unittest_nnstreamer-edge
+
+%if 0%{?aitt_support}
 LD_LIBRARY_PATH=./src bash %{test_script} ./tests/unittest_nnstreamer-edge-aitt
+%endif
 
 %if 0%{?testcoverage}
 # 'lcov' generates the date format with UTC time zone by default. Let's replace UTC with KST.
@@ -158,7 +161,10 @@ rm -rf %{buildroot}
 %manifest nnstreamer-edge.manifest
 %defattr(-,root,root,-)
 %{_bindir}/unittest_nnstreamer-edge
+
+%if 0%{?aitt_support}
 %{_bindir}/unittest_nnstreamer-edge-aitt
+%endif
 
 %if 0%{?testcoverage}
 %files unittest-coverage

--- a/tests/unittest_nnstreamer-edge-aitt.cc
+++ b/tests/unittest_nnstreamer-edge-aitt.cc
@@ -131,7 +131,7 @@ _check_mqtt_broker ()
 /**
  * @brief Connect to local host, multiple clients.
  */
-TEST(edge, connectLocal)
+TEST(edgeAitt, connectLocal)
 {
   nns_edge_h server_h, client1_h, client2_h;
   ne_test_data_s *_td_server, *_td_client1, *_td_client2;

--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -2203,7 +2203,6 @@ TEST(edgeDataSerialize, invalidParam04_n)
 TEST(edgeDataDeserialize, invalidParam01_n)
 {
   void *data = NULL;
-  size_t data_len;
   int ret;
 
   ret = nns_edge_data_deserialize (NULL, data);


### PR DESCRIPTION
- Exclude Aitt related files when aitt_support is not set.
- Remove unused variable and change test name.