### PR TITLE
Fixate the data size @open sesame 10/14 10:07

### DIFF
--- a/include/nnstreamer-edge.h
+++ b/include/nnstreamer-edge.h
@@ -13,6 +13,7 @@
 #ifndef __NNSTREAMER_EDGE_H__
 #define __NNSTREAMER_EDGE_H__
 
+#include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +25,8 @@ extern "C" {
 typedef void *nns_edge_h;
 typedef void *nns_edge_event_h;
 typedef void *nns_edge_data_h;
+typedef uint64_t nns_size_t;
+typedef int64_t nns_ssize_t;
 
 /**
  * @brief The maximum number of data instances that nnstreamer-edge data may have.
@@ -389,7 +392,7 @@ int nns_edge_data_copy (nns_edge_data_h data_h, nns_edge_data_h *new_data_h);
  * @retval #NNS_EDGE_ERROR_NOT_SUPPORTED Not supported.
  * @retval #NNS_EDGE_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_edge_data_add (nns_edge_data_h data_h, void *data, size_t data_len, nns_edge_data_destroy_cb destroy_cb);
+int nns_edge_data_add (nns_edge_data_h data_h, void *data, nns_size_t data_len, nns_edge_data_destroy_cb destroy_cb);
 
 /**
  * @brief Get the n'th edge data.
@@ -403,7 +406,7 @@ int nns_edge_data_add (nns_edge_data_h data_h, void *data, size_t data_len, nns_
  * @retval #NNS_EDGE_ERROR_NOT_SUPPORTED Not supported.
  * @retval #NNS_EDGE_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_edge_data_get (nns_edge_data_h data_h, unsigned int index, void **data, size_t *data_len);
+int nns_edge_data_get (nns_edge_data_h data_h, unsigned int index, void **data, nns_size_t *data_len);
 
 /**
  * @brief Get the number of edge data in handle.

--- a/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
@@ -181,7 +181,7 @@ nns_edge_aitt_publish (nns_edge_h edge_h, const void *data, const int length)
  */
 static int
 _nns_edge_invoke_event_cb (nns_edge_handle_s * eh, nns_edge_event_e event,
-    void *data, size_t data_len, nns_edge_data_destroy_cb destroy_cb)
+    void *data, nns_size_t data_len, nns_edge_data_destroy_cb destroy_cb)
 {
   nns_edge_event_h event_h;
   int ret;

--- a/src/libnnstreamer-edge/nnstreamer-edge-data.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-data.c
@@ -176,7 +176,7 @@ done:
  * @brief Add raw data into nnstreamer edge data.
  */
 int
-nns_edge_data_add (nns_edge_data_h data_h, void *data, size_t data_len,
+nns_edge_data_add (nns_edge_data_h data_h, void *data, nns_size_t data_len,
     nns_edge_data_destroy_cb destroy_cb)
 {
   nns_edge_data_s *ed;
@@ -221,7 +221,7 @@ nns_edge_data_add (nns_edge_data_h data_h, void *data, size_t data_len,
  */
 int
 nns_edge_data_get (nns_edge_data_h data_h, unsigned int index, void **data,
-    size_t *data_len)
+    nns_size_t * data_len)
 {
   nns_edge_data_s *ed;
 
@@ -371,7 +371,7 @@ nns_edge_data_get_info (nns_edge_data_h data_h, const char *key, char **value)
  */
 int
 nns_edge_data_serialize_meta (nns_edge_data_h data_h, void **data,
-    size_t *data_len)
+    nns_size_t * data_len)
 {
   nns_edge_data_s *ed;
   int ret;
@@ -401,7 +401,7 @@ nns_edge_data_serialize_meta (nns_edge_data_h data_h, void **data,
  */
 int
 nns_edge_data_deserialize_meta (nns_edge_data_h data_h, void *data,
-    size_t data_len)
+    nns_size_t data_len)
 {
   nns_edge_data_s *ed;
   int ret;
@@ -430,12 +430,12 @@ nns_edge_data_deserialize_meta (nns_edge_data_h data_h, void *data,
  * @brief Serialize edge data (meta data + raw data).
  */
 int
-nns_edge_data_serialize (nns_edge_data_h data_h, void **data, size_t *len)
+nns_edge_data_serialize (nns_edge_data_h data_h, void **data, nns_size_t * len)
 {
   nns_edge_data_s *ed;
   nns_edge_data_header_s edata_header;
   void *meta_serialized = NULL;
-  size_t total, header_len, data_len;
+  nns_size_t total, header_len, data_len;
   char *serialized, *ptr;
   unsigned int n;
   int ret;
@@ -509,7 +509,7 @@ nns_edge_data_deserialize (nns_edge_data_h data_h, void *data)
   nns_edge_data_header_s *header;
   int ret;
   unsigned int n;
-  size_t meta_len;
+  nns_size_t meta_len;
   char *ptr;
 
   ed = (nns_edge_data_s *) data_h;

--- a/src/libnnstreamer-edge/nnstreamer-edge-data.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-data.h
@@ -26,9 +26,9 @@ extern "C" {
  * @brief Internal data structure for edge data.
  */
 typedef struct {
-  unsigned int magic;
+  uint32_t magic;
   pthread_mutex_t lock;
-  unsigned int num;
+  uint32_t num;
   nns_edge_raw_data_s data[NNS_EDGE_DATA_LIMIT];
   nns_edge_metadata_h metadata;
 } nns_edge_data_s;
@@ -37,9 +37,9 @@ typedef struct {
  * @brief Internal data structure for the header of the serialzied edge data.
  */
 typedef struct {
-  unsigned int num_mem;
-  size_t data_len[NNS_EDGE_DATA_LIMIT];
-  size_t meta_len;
+  uint32_t num_mem;
+  nns_size_t data_len[NNS_EDGE_DATA_LIMIT];
+  nns_size_t meta_len;
 } nns_edge_data_header_s;
 
 /**
@@ -52,19 +52,19 @@ int nns_edge_data_is_valid (nns_edge_data_h data_h);
  * @brief Serialize metadata in edge data.
  * @note This is internal function, DO NOT export this. Caller should release the returned value using free().
  */
-int nns_edge_data_serialize_meta (nns_edge_data_h data_h, void **data, size_t *data_len);
+int nns_edge_data_serialize_meta (nns_edge_data_h data_h, void **data, nns_size_t *data_len);
 
 /**
  * @brief Deserialize metadata in edge data.
  * @note This is internal function, DO NOT export this. Caller should release the returned value using free().
  */
-int nns_edge_data_deserialize_meta (nns_edge_data_h data_h, void *data, size_t data_len);
+int nns_edge_data_deserialize_meta (nns_edge_data_h data_h, void *data, nns_size_t data_len);
 
 /**
  * @brief Serialize entire edge data (meta data + raw data).
  * @note This is internal function, DO NOT export this. Caller should release the returned value using free().
  */
-int nns_edge_data_serialize (nns_edge_data_h data_h, void **data, size_t *data_len);
+int nns_edge_data_serialize (nns_edge_data_h data_h, void **data, nns_size_t *data_len);
 
 /**
  * @brief Deserialize entire edge data (meta data + raw data).

--- a/src/libnnstreamer-edge/nnstreamer-edge-event.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-event.c
@@ -75,8 +75,8 @@ nns_edge_event_destroy (nns_edge_event_h event_h)
  * @brief Set event data.
  */
 int
-nns_edge_event_set_data (nns_edge_event_h event_h, void *data, size_t data_len,
-    nns_edge_data_destroy_cb destroy_cb)
+nns_edge_event_set_data (nns_edge_event_h event_h, void *data,
+    nns_size_t data_len, nns_edge_data_destroy_cb destroy_cb)
 {
   nns_edge_event_s *ee;
 

--- a/src/libnnstreamer-edge/nnstreamer-edge-event.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-event.h
@@ -36,7 +36,7 @@ int nns_edge_event_destroy (nns_edge_event_h event_h);
  * @brief Set event data.
  * @note This is internal function for edge event.
  */
-int nns_edge_event_set_data (nns_edge_event_h event_h, void *data, size_t data_len, nns_edge_data_destroy_cb destroy_cb);
+int nns_edge_event_set_data (nns_edge_event_h event_h, void *data, nns_size_t data_len, nns_edge_data_destroy_cb destroy_cb);
 
 #ifdef __cplusplus
 }

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -48,14 +48,14 @@ typedef enum
  */
 typedef struct
 {
-  unsigned int magic;
+  uint32_t magic;
   nns_edge_cmd_e cmd;
   int64_t client_id;
 
   /* memory info */
   uint32_t num;
-  size_t mem_size[NNS_EDGE_DATA_LIMIT];
-  size_t meta_size;
+  nns_size_t mem_size[NNS_EDGE_DATA_LIMIT];
+  nns_size_t meta_size;
 } nns_edge_cmd_info_s;
 
 /**
@@ -150,10 +150,10 @@ _fill_socket_addr (struct sockaddr_in *saddr, const char *host, const int port)
  * @brief Send data to connected socket.
  */
 static bool
-_send_raw_data (nns_edge_conn_s * conn, void *data, size_t size)
+_send_raw_data (nns_edge_conn_s * conn, void *data, nns_size_t size)
 {
-  size_t sent = 0;
-  ssize_t rret;
+  nns_size_t sent = 0;
+  nns_ssize_t rret;
 
   while (sent < size) {
     rret = send (conn->sockfd, (char *) data + sent, size - sent, MSG_NOSIGNAL);
@@ -173,10 +173,10 @@ _send_raw_data (nns_edge_conn_s * conn, void *data, size_t size)
  * @brief Receive data from connected socket.
  */
 static bool
-_receive_raw_data (nns_edge_conn_s * conn, void *data, size_t size)
+_receive_raw_data (nns_edge_conn_s * conn, void *data, nns_size_t size)
 {
-  size_t received = 0;
-  ssize_t rret;
+  nns_size_t received = 0;
+  nns_ssize_t rret;
 
   while (received < size) {
     rret = recv (conn->sockfd, (char *) data + received, size - received, 0);
@@ -337,7 +337,7 @@ _nns_edge_cmd_send_aitt (nns_edge_handle_s * eh, nns_edge_data_h data_h)
 {
   int ret;
   void *data = NULL;
-  size_t size;
+  nns_size_t size;
 
   if (!eh) {
     nns_edge_loge ("Failed to send command, edge handle is null.");
@@ -472,7 +472,7 @@ _nns_edge_transfer_data (nns_edge_conn_s * conn, nns_edge_data_h data_h,
  */
 static int
 _nns_edge_invoke_event_cb (nns_edge_handle_s * eh, nns_edge_event_e event,
-    void *data, size_t data_len, nns_edge_data_destroy_cb destroy_cb)
+    void *data, nns_size_t data_len, nns_edge_data_destroy_cb destroy_cb)
 {
   nns_edge_event_h event_h;
   int ret;
@@ -778,7 +778,7 @@ _nns_edge_message_handler (void *thread_data)
 
   /* Received error message from client, remove connection from table. */
   if (remove_connection) {
-    nns_edge_logd
+    nns_edge_loge
         ("Received error from client, remove connection of client (ID: %lld).",
         (long long) client_id);
     _nns_edge_remove_connection (eh, client_id);

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.h
@@ -29,7 +29,7 @@ extern "C" {
  */
 typedef struct {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   nns_edge_data_destroy_cb destroy_cb;
 } nns_edge_raw_data_s;
 
@@ -37,7 +37,7 @@ typedef struct {
  * @brief Internal data structure for edge event.
  */
 typedef struct {
-  unsigned int magic;
+  uint32_t magic;
   nns_edge_event_e event;
   nns_edge_raw_data_s data;
 } nns_edge_event_s;
@@ -46,7 +46,7 @@ typedef struct {
  * @brief Data structure for edge handle.
  */
 typedef struct {
-  unsigned int magic;
+  uint32_t magic;
   pthread_mutex_t lock;
   char *id;
   char *topic;

--- a/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
@@ -33,7 +33,7 @@ struct _nns_edge_metadata_node_s
  */
 typedef struct
 {
-  unsigned int list_len;
+  uint32_t list_len;
   nns_edge_metadata_node_s *list;
 } nns_edge_metadata_s;
 
@@ -265,12 +265,13 @@ nns_edge_metadata_copy (nns_edge_metadata_h dest_h, nns_edge_metadata_h src_h)
  */
 int
 nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
-    void **data, size_t *data_len)
+    void **data, nns_size_t * data_len)
 {
   nns_edge_metadata_s *meta;
   nns_edge_metadata_node_s *node;
   char *serialized, *ptr;
-  size_t total, len;
+  nns_size_t total;
+  uint32_t len;
 
   meta = (nns_edge_metadata_s *) metadata_h;
 
@@ -286,7 +287,7 @@ nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
   if (meta->list_len == 0)
     return NNS_EDGE_ERROR_NONE;
 
-  total = len = sizeof (unsigned int);
+  total = len = sizeof (uint32_t);
 
   node = meta->list;
   while (node) {
@@ -299,7 +300,7 @@ nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
     return NNS_EDGE_ERROR_OUT_OF_MEMORY;
 
   /* length + list of key-value pair */
-  ((unsigned int *) serialized)[0] = meta->list_len;
+  ((uint32_t *) serialized)[0] = meta->list_len;
   ptr += len;
 
   node = meta->list;
@@ -328,12 +329,11 @@ nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
  */
 int
 nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h,
-    void *data, size_t data_len)
+    void *data, nns_size_t data_len)
 {
   nns_edge_metadata_s *meta;
   char *key, *value;
-  size_t cur;
-  unsigned int total;
+  nns_size_t cur, total;
   int ret;
 
   meta = (nns_edge_metadata_s *) metadata_h;
@@ -347,9 +347,9 @@ nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h,
   nns_edge_metadata_free (meta);
 
   /* length + list of key-value pair */
-  total = ((unsigned int *) data)[0];
+  total = ((uint32_t *) data)[0];
 
-  cur = sizeof (unsigned int);
+  cur = sizeof (uint32_t);
   while (cur < data_len || meta->list_len < total) {
     key = (char *) data + cur;
     cur += (strlen (key) + 1);

--- a/src/libnnstreamer-edge/nnstreamer-edge-metadata.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-metadata.h
@@ -50,12 +50,12 @@ int nns_edge_metadata_copy (nns_edge_metadata_h dest_h, nns_edge_metadata_h src_
 /**
  * @brief Internal function to serialize the metadata. Caller should release the returned value using free().
  */
-int nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h, void **data, size_t *data_len);
+int nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h, void **data, nns_size_t *data_len);
 
 /**
  * @brief Internal function to deserialize memory into metadata.
  */
-int nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h, void *data, size_t data_len);
+int nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h, void *data, nns_size_t data_len);
 
 #ifdef __cplusplus
 }

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.c
@@ -123,7 +123,7 @@ nns_edge_free (void *data)
  * @note Caller should release newly allocated memory using nns_edge_free().
  */
 void *
-nns_edge_memdup (const void *data, size_t size)
+nns_edge_memdup (const void *data, nns_size_t size)
 {
   void *mem = NULL;
 
@@ -160,7 +160,7 @@ nns_edge_strdup (const char *str)
  * @note Caller should release newly allocated string using nns_edge_free().
  */
 char *
-nns_edge_strndup (const char *str, size_t len)
+nns_edge_strndup (const char *str, nns_size_t len)
 {
   char *new_str = NULL;
 

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.h
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "nnstreamer-edge.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,7 +94,7 @@ void nns_edge_free (void *data);
  * @brief Allocate new memory and copy bytes.
  * @note Caller should release newly allocated memory using nns_edge_free().
  */
-void *nns_edge_memdup (const void *data, size_t size);
+void *nns_edge_memdup (const void *data, nns_size_t size);
 
 /**
  * @brief Allocate new memory and copy string.
@@ -105,7 +106,7 @@ char *nns_edge_strdup (const char *str);
  * @brief Allocate new memory and copy bytes of string.
  * @note Caller should release newly allocated string using nns_edge_free().
  */
-char *nns_edge_strndup (const char *str, size_t len);
+char *nns_edge_strndup (const char *str, nns_size_t len);
 
 /**
  * @brief Allocate new memory and print formatted string.

--- a/tests/unittest_nnstreamer-edge-aitt.cc
+++ b/tests/unittest_nnstreamer-edge-aitt.cc
@@ -64,7 +64,7 @@ _test_edge_event_cb (nns_edge_event_h event_h, void *user_data)
   nns_edge_event_e event = NNS_EDGE_EVENT_UNKNOWN;
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   unsigned int i, count;
   int ret;
 
@@ -135,7 +135,7 @@ TEST(edgeAitt, connectLocal)
   nns_edge_h server_h, client1_h, client2_h;
   ne_test_data_s *_td_server, *_td_client1, *_td_client2;
   nns_edge_data_h data_h;
-  size_t data_len;
+  nns_size_t data_len;
   void *data1, *data2;
   unsigned int i, retry;
   int ret, port;

--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -68,7 +68,7 @@ _test_edge_event_cb (nns_edge_event_h event_h, void *user_data)
   nns_edge_event_e event = NNS_EDGE_EVENT_UNKNOWN;
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   char *val;
   unsigned int i, count;
   int ret;
@@ -138,7 +138,7 @@ TEST(edge, connectLocal)
   nns_edge_h server_h, client1_h, client2_h;
   ne_test_data_s *_td_server, *_td_client1, *_td_client2;
   nns_edge_data_h data_h;
-  size_t data_len;
+  nns_size_t data_len;
   void *data;
   unsigned int i, retry;
   int ret, port;
@@ -1136,7 +1136,7 @@ TEST(edgeData, copy)
 {
   nns_edge_data_h src_h, desc_h;
   void *data, *result;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   char *result_value;
   unsigned int i, result_count;
   int ret;
@@ -1250,7 +1250,7 @@ TEST(edgeData, addMaxData_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int i, ret;
 
   data_len = 10U * sizeof (int);
@@ -1280,7 +1280,7 @@ TEST(edgeData, addMaxData_n)
 TEST(edgeData, addInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1301,7 +1301,7 @@ TEST(edgeData, addInvalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1332,7 +1332,7 @@ TEST(edgeData, addInvalidParam03_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1358,7 +1358,7 @@ TEST(edgeData, addInvalidParam04_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1384,7 +1384,7 @@ TEST(edgeData, get)
 {
   nns_edge_data_h data_h;
   void *data, *result;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   unsigned int count;
   int ret;
 
@@ -1419,7 +1419,7 @@ TEST(edgeData, get)
 TEST(edgeData, getInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_get (NULL, 0, &data, &data_len);
@@ -1434,7 +1434,7 @@ TEST(edgeData, getInvalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data, *result;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1468,7 +1468,7 @@ TEST(edgeData, getInvalidParam03_n)
 {
   nns_edge_data_h data_h;
   void *data, *result;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1498,7 +1498,7 @@ TEST(edgeData, getInvalidParam04_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1527,7 +1527,7 @@ TEST(edgeData, getInvalidParam05_n)
 {
   nns_edge_data_h data_h;
   void *data, *result;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1569,7 +1569,7 @@ TEST(edgeData, getCountInvalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   unsigned int count;
   int ret;
 
@@ -1604,7 +1604,7 @@ TEST(edgeData, getCountInvalidParam03_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -1807,7 +1807,7 @@ TEST(edgeData, getInfoInvalidParam05_n)
 TEST(edgeData, serializeInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_serialize_meta (NULL, &data, &data_len);
@@ -1822,7 +1822,7 @@ TEST(edgeData, serializeInvalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -1849,7 +1849,7 @@ TEST(edgeData, serializeInvalidParam02_n)
 TEST(edgeData, serializeInvalidParam03_n)
 {
   nns_edge_data_h data_h;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -1894,7 +1894,7 @@ TEST(edgeData, deserializeInvalidParam01_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -1923,7 +1923,7 @@ TEST(edgeData, deserializeInvalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -1956,7 +1956,7 @@ TEST(edgeData, deserializeInvalidParam03_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -1984,7 +1984,7 @@ TEST(edgeData, deserializeInvalidParam04_n)
 {
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -2013,7 +2013,7 @@ TEST(edgeDataSerialize, normal)
 {
   nns_edge_data_h src_h, dest_h;
   void *data1, *data2, *result, *serialized_data;
-  size_t data_len, result_len, serialized_len;
+  nns_size_t data_len, result_len, serialized_len;
   char *result_value;
   unsigned int i, result_count;
   int ret;
@@ -2092,7 +2092,7 @@ TEST(edgeDataSerialize, normal)
 TEST(edgeDataSerialize, invalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_serialize (NULL, &data, &data_len);
@@ -2107,7 +2107,7 @@ TEST(edgeData, invalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -2134,7 +2134,7 @@ TEST(edgeData, invalidParam02_n)
 TEST(edgeDataSerialize, invalidParam03_n)
 {
   nns_edge_data_h data_h;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -2194,7 +2194,7 @@ TEST(edgeDataDeserialize, invalidParam02_n)
   nns_edge_data_h data_h;
   nns_edge_data_s *ed;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -2280,7 +2280,7 @@ TEST(edgeEvent, destroyInvalidParam02_n)
   nns_edge_event_h event_h;
   nns_edge_event_s *ee;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -2311,7 +2311,7 @@ TEST(edgeEvent, destroyInvalidParam02_n)
 TEST(edgeEvent, setDataInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -2331,7 +2331,7 @@ TEST(edgeEvent, setDataInvalidParam02_n)
 {
   nns_edge_event_h event_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -2357,7 +2357,7 @@ TEST(edgeEvent, setDataInvalidParam03_n)
 {
   nns_edge_event_h event_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -2384,7 +2384,7 @@ TEST(edgeEvent, setDataInvalidParam04_n)
   nns_edge_event_h event_h;
   nns_edge_event_s *ee;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U * sizeof (int);
@@ -2491,7 +2491,7 @@ TEST(edgeEvent, parseNewData)
   nns_edge_event_h event_h;
   nns_edge_data_h data_h, result_h;
   void *data, *result;
-  size_t data_len, result_len;
+  nns_size_t data_len, result_len;
   char *result_value;
   unsigned int i, count;
   int ret;
@@ -2985,7 +2985,7 @@ TEST(edgeMeta, serialize)
   nns_edge_metadata_h src, desc;
   char *value;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_metadata_create (&src);
@@ -3035,7 +3035,7 @@ TEST(edgeMeta, serialize)
 TEST(edgeMeta, serializeInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_metadata_serialize (NULL, &data, &data_len);
@@ -3048,7 +3048,7 @@ TEST(edgeMeta, serializeInvalidParam01_n)
 TEST(edgeMeta, serializeInvalidParam02_n)
 {
   nns_edge_metadata_h meta;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_metadata_create (&meta);
@@ -3086,7 +3086,7 @@ TEST(edgeMeta, serializeInvalidParam03_n)
 TEST(edgeMeta, deserializeInvalidParam01_n)
 {
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U + sizeof (unsigned int);
@@ -3106,7 +3106,7 @@ TEST(edgeMeta, deserializeInvalidParam01_n)
 TEST(edgeMeta, deserializeInvalidParam02_n)
 {
   nns_edge_metadata_h meta;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U + sizeof (unsigned int);
@@ -3128,7 +3128,7 @@ TEST(edgeMeta, deserializeInvalidParam03_n)
 {
   nns_edge_metadata_h meta;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   int ret;
 
   data_len = 10U + sizeof (unsigned int);
@@ -3414,7 +3414,7 @@ _test_edge_hybrid_event_cb (nns_edge_event_h event_h, void *user_data)
   nns_edge_event_e event = NNS_EDGE_EVENT_UNKNOWN;
   nns_edge_data_h data_h;
   void *data;
-  size_t data_len;
+  nns_size_t data_len;
   char *val;
   unsigned int i, count;
   int ret;
@@ -3494,7 +3494,7 @@ TEST(edgeMqtt, connectLocal)
   nns_edge_h server_h, client_h;
   ne_test_data_s *_td_server, *_td_client;
   nns_edge_data_h data_h;
-  size_t data_len;
+  nns_size_t data_len;
   void *data;
   unsigned int i, retry;
   int ret = 0;


### PR DESCRIPTION
An error occurs in the communication because of different data sizes in the 32-bit and the 64-bit systems. Fixate the data size.

Tested using 32bit Tizen TV and 64bit Ubuntu.

Signed-off-by: gichan <gichan2.jang@samsung.com>