### PR TITLE
[edge] Remove unnecessary pthread call

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -524,7 +524,6 @@ _nns_edge_close_connection (nns_edge_conn_s * conn)
   /* Stop and clear the message thread. */
   if (conn->msg_thread) {
     if (conn->running) {
-      pthread_cancel (conn->msg_thread);
       conn->running = false;
     }
     pthread_join (conn->msg_thread, NULL);
@@ -1417,7 +1416,6 @@ nns_edge_release_handle (nns_edge_h edge_h)
 
   if (eh->listener_thread) {
     if (eh->listening) {
-      pthread_cancel (eh->listener_thread);
       eh->listening = false;
     }
 


### PR DESCRIPTION
- Remove `pthread_cancel`, cause msg and listener thread do not handle thread cancellation.
- By the way, Android NDK does not support `pthread_cancel`.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>