### PR TITLE
CMake: FATAL_ERROR should not be in message string. @open sesame 11/03 10:43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ IF(MQTT_SUPPORT)
             FIND_LIBRARY(PAHO_MQTT_LIB NAMES paho-mqtt3a paho-mqtt3c paho-mqtt3as paho-mqtt3cs)
 
             IF(NOT PAHO_MQTT_LIB)
-                MESSAGE("FATAL_ERROR Cannot find paho-mqtt-c and mosquitto library.")
+                MESSAGE(FATAL_ERROR "Cannot find paho-mqtt-c and mosquitto library.")
             ELSE()
                 MESSAGE("Found Paho MQTT library.")
             ENDIF()


### PR DESCRIPTION
It should be given as the optional mode argument.
Refer to https://cmake.org/cmake/help/v3.0/command/message.html

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>