### PR TITLE
[TEST] Adjust sleep time of AITT test. 

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
@@ -221,7 +221,7 @@ error:
  */
 static void
 aitt_cb_message_arrived (aitt_msg_h msg_handle, const void *msg,
-    size_t msg_len, void *user_data)
+    int msg_len, void *user_data)
 {
   nns_edge_handle_s *eh;
   nns_edge_data_h data_h;

--- a/tests/unittest_nnstreamer-edge-aitt.cc
+++ b/tests/unittest_nnstreamer-edge-aitt.cc
@@ -190,8 +190,7 @@ TEST(edgeAitt, connectLocal)
   usleep (10000);
   ret = nns_edge_connect (client2_h, "127.0.0.1", 1883);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
-
-  sleep (2);
+  usleep (10000);
 
   /* Send request to server */
   data_len = 10U * sizeof (unsigned int);


### PR DESCRIPTION
AITT check its connection every 1 second, so reduce unnecessary long sleep time.

Signed-off-by: gichan <gichan2.jang@samsung.com>