### PR TITLE
[build] Add nnstreamer-edge-log.c to android build 

### DIFF
--- a/jni/nnstreamer-edge.mk
+++ b/jni/nnstreamer-edge.mk
@@ -13,6 +13,7 @@ NNSTREAMER_EDGE_SRCS := \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-data.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-event.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-internal.c \
+    $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-log.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-metadata.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-queue.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-util.c

--- a/src/libnnstreamer-edge/nnstreamer-edge-log.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-log.c
@@ -13,6 +13,10 @@
 #include <stdarg.h>
 #include "nnstreamer-edge-log.h"
 
+#ifndef DEBUG
+#define DEBUG 0
+#endif
+
 #if defined(__TIZEN__)
 #include <dlog.h>
 


### PR DESCRIPTION
- Add DEBUG macro value as 0 if it is not defined before
- Add the source file to the source list in Android.mk