### PR TITLE
[Util] util function to allocate memory

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-data.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-data.c
@@ -471,7 +471,7 @@ nns_edge_data_serialize (nns_edge_data_h data_h, void **data, nns_size_t * len)
 
   total = header_len + data_len + edata_header.meta_len;
 
-  serialized = ptr = (char *) malloc (total);
+  serialized = ptr = (char *) nns_edge_malloc (total);
   if (!serialized) {
     ret = NNS_EDGE_ERROR_OUT_OF_MEMORY;
     goto done;

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -396,7 +396,7 @@ _nns_edge_cmd_receive (nns_edge_conn_s * conn, nns_edge_cmd_s * cmd)
   }
 
   for (n = 0; n < cmd->info.num; n++) {
-    cmd->mem[n] = malloc (cmd->info.mem_size[n]);
+    cmd->mem[n] = nns_edge_malloc (cmd->info.mem_size[n]);
     if (!cmd->mem[n]) {
       nns_edge_loge ("Failed to allocate memory to receive data from socket.");
       ret = NNS_EDGE_ERROR_OUT_OF_MEMORY;
@@ -411,7 +411,7 @@ _nns_edge_cmd_receive (nns_edge_conn_s * conn, nns_edge_cmd_s * cmd)
   }
 
   if (cmd->info.meta_size > 0) {
-    cmd->meta = malloc (cmd->info.meta_size);
+    cmd->meta = nns_edge_malloc (cmd->info.meta_size);
     if (!cmd->meta) {
       nns_edge_loge ("Failed to allocate memory to receive meta from socket.");
       ret = NNS_EDGE_ERROR_OUT_OF_MEMORY;

--- a/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
@@ -295,7 +295,7 @@ nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
     node = node->next;
   }
 
-  serialized = ptr = (char *) malloc (total);
+  serialized = ptr = (char *) nns_edge_malloc (total);
   if (!serialized)
     return NNS_EDGE_ERROR_OUT_OF_MEMORY;
 

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.c
@@ -110,6 +110,24 @@ nns_edge_parse_port_number (const char *port_str)
 }
 
 /**
+ * @brief Allocate new memory. The max size is SIZE_MAX.
+ * @note Caller should release newly allocated memory using nns_edge_free().
+ */
+void *
+nns_edge_malloc (nns_size_t size)
+{
+  void *mem = NULL;
+
+  if (size > 0 && size <= SIZE_MAX)
+    mem = malloc (size);
+
+  if (!mem)
+    nns_edge_loge ("Failed to allocate memory (%llu).", size);
+
+  return mem;
+}
+
+/**
  * @brief Free allocated memory.
  */
 void
@@ -129,13 +147,10 @@ nns_edge_memdup (const void *data, nns_size_t size)
   void *mem = NULL;
 
   if (data && size > 0) {
-    mem = malloc (size);
+    mem = nns_edge_malloc (size);
 
-    if (mem) {
+    if (mem)
       memcpy (mem, data, size);
-    } else {
-      nns_edge_loge ("Failed to allocate memory (%llu).", size);
-    }
   }
 
   return mem;
@@ -166,13 +181,11 @@ nns_edge_strndup (const char *str, nns_size_t len)
   char *new_str = NULL;
 
   if (str) {
-    new_str = (char *) malloc (len + 1);
+    new_str = (char *) nns_edge_malloc (len + 1);
 
     if (new_str) {
       strncpy (new_str, str, len);
       new_str[len] = '\0';
-    } else {
-      nns_edge_loge ("Failed to allocate memory (%llu).", len + 1);
     }
   }
 

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.h
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 #include "nnstreamer-edge.h"
 
 #ifdef __cplusplus
@@ -39,6 +40,13 @@ extern "C" {
 
 #ifndef FALSE
 #define FALSE (0)
+#endif
+
+/**
+ * @brief The max size to allocate memory. This would be defined in C99 limits.h.
+ */
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t) -1)
 #endif
 
 #define STR_IS_VALID(s) ((s) && (s)[0] != '\0')
@@ -84,6 +92,12 @@ void nns_edge_parse_host_string (const char *host_str, char **host, int *port);
  * @brief Parse string and get port number. Return negative value when failed to get port number.
  */
 int nns_edge_parse_port_number (const char *port_str);
+
+/**
+ * @brief Allocate new memory. The max size is SIZE_MAX.
+ * @note Caller should release newly allocated memory using nns_edge_free().
+ */
+void *nns_edge_malloc (nns_size_t size);
 
 /**
  * @brief Free allocated memory.


### PR DESCRIPTION
Fix svace issue - size limit to allocate memory.

Add util function for mem allocation, checking max size before calling malloc.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>