### PR TITLE
[CodeClean/Data] param to deserialize edge-data

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-aitt.c
@@ -238,7 +238,7 @@ aitt_cb_message_arrived (aitt_msg_h msg_handle, const void *msg,
     return;
   }
 
-  nns_edge_data_deserialize (data_h, (void *) msg);
+  nns_edge_data_deserialize (data_h, (void *) msg, (nns_size_t) msg_len);
 
   _nns_edge_invoke_event_cb (eh, NNS_EDGE_EVENT_NEW_DATA_RECEIVED, data_h,
       sizeof (nns_edge_data_h), NULL);

--- a/src/libnnstreamer-edge/nnstreamer-edge-data.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-data.h
@@ -61,9 +61,9 @@ int nns_edge_data_serialize_meta (nns_edge_data_h data_h, void **data, nns_size_
 
 /**
  * @brief Deserialize metadata in edge data.
- * @note This is internal function, DO NOT export this. Caller should release the returned value using free().
+ * @note This is internal function, DO NOT export this.
  */
-int nns_edge_data_deserialize_meta (nns_edge_data_h data_h, void *data, nns_size_t data_len);
+int nns_edge_data_deserialize_meta (nns_edge_data_h data_h, const void *data, const nns_size_t data_len);
 
 /**
  * @brief Serialize entire edge data (meta data + raw data).
@@ -73,9 +73,9 @@ int nns_edge_data_serialize (nns_edge_data_h data_h, void **data, nns_size_t *da
 
 /**
  * @brief Deserialize entire edge data (meta data + raw data).
- * @note This is internal function, DO NOT export this. Caller should release the returned value using free().
+ * @note This is internal function, DO NOT export this.
  */
-int nns_edge_data_deserialize (nns_edge_data_h data_h, void *data);
+int nns_edge_data_deserialize (nns_edge_data_h data_h, const void *data, const nns_size_t data_len);
 
 #ifdef __cplusplus
 }

--- a/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-metadata.c
@@ -329,7 +329,7 @@ nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h,
  */
 int
 nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h,
-    void *data, nns_size_t data_len)
+    const void *data, const nns_size_t data_len)
 {
   nns_edge_metadata_s *meta;
   char *key, *value;

--- a/src/libnnstreamer-edge/nnstreamer-edge-metadata.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-metadata.h
@@ -55,7 +55,7 @@ int nns_edge_metadata_serialize (nns_edge_metadata_h metadata_h, void **data, nn
 /**
  * @brief Internal function to deserialize memory into metadata.
  */
-int nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h, void *data, nns_size_t data_len);
+int nns_edge_metadata_deserialize (nns_edge_metadata_h metadata_h, const void *data, const nns_size_t data_len);
 
 #ifdef __cplusplus
 }

--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -1909,7 +1909,7 @@ TEST(edgeData, serializeInvalidParam04_n)
 }
 
 /**
- * @brief Derialize meta to edge-data - invalid param.
+ * @brief Deserialize meta to edge-data - invalid param.
  */
 TEST(edgeData, deserializeInvalidParam01_n)
 {
@@ -1937,7 +1937,7 @@ TEST(edgeData, deserializeInvalidParam01_n)
 }
 
 /**
- * @brief Derialize meta to edge-data - invalid param.
+ * @brief Deserialize meta to edge-data - invalid param.
  */
 TEST(edgeData, deserializeInvalidParam02_n)
 {
@@ -1971,7 +1971,7 @@ TEST(edgeData, deserializeInvalidParam02_n)
 }
 
 /**
- * @brief Derialize meta to edge-data - invalid param.
+ * @brief Deserialize meta to edge-data - invalid param.
  */
 TEST(edgeData, deserializeInvalidParam03_n)
 {
@@ -1999,7 +1999,7 @@ TEST(edgeData, deserializeInvalidParam03_n)
 }
 
 /**
- * @brief Derialize meta to edge-data - invalid param.
+ * @brief Deserialize meta to edge-data - invalid param.
  */
 TEST(edgeData, deserializeInvalidParam04_n)
 {
@@ -2074,7 +2074,7 @@ TEST(edgeDataSerialize, normal)
   ret = nns_edge_data_create (&dest_h);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
-  ret = nns_edge_data_deserialize (dest_h, serialized_data);
+  ret = nns_edge_data_deserialize (dest_h, serialized_data, serialized_len);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
   /* Compare data and info */
@@ -2194,21 +2194,21 @@ TEST(edgeDataSerialize, invalidParam04_n)
 }
 
 /**
- * @brief Derialize edge-data - invalid param.
+ * @brief Deserialize edge-data - invalid param.
  */
 TEST(edgeDataDeserialize, invalidParam01_n)
 {
   void *data = NULL;
   int ret;
 
-  ret = nns_edge_data_deserialize (NULL, data);
+  ret = nns_edge_data_deserialize (NULL, data, 10U);
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
 
   nns_edge_free (data);
 }
 
 /**
- * @brief Derialize edge-data - invalid param.
+ * @brief Deserialize edge-data - invalid param.
  */
 TEST(edgeDataDeserialize, invalidParam02_n)
 {
@@ -2224,13 +2224,13 @@ TEST(edgeDataDeserialize, invalidParam02_n)
   ret = nns_edge_data_set_info (data_h, "temp-key", "temp-value");
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
-  ret = nns_edge_data_serialize_meta (data_h, &data, &data_len);
+  ret = nns_edge_data_serialize (data_h, &data, &data_len);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
   ed = (nns_edge_data_s *) data_h;
   ed->magic = NNS_EDGE_MAGIC_DEAD;
 
-  ret = nns_edge_data_deserialize (data_h, data);
+  ret = nns_edge_data_deserialize (data_h, data, data_len);
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
 
   ed->magic = NNS_EDGE_MAGIC;
@@ -2242,11 +2242,13 @@ TEST(edgeDataDeserialize, invalidParam02_n)
 }
 
 /**
- * @brief Derialize edge-data - invalid param.
+ * @brief Deserialize edge-data - invalid param.
  */
 TEST(edgeDataDeserialize, invalidParam03_n)
 {
   nns_edge_data_h data_h;
+  void *data;
+  nns_size_t data_len;
   int ret;
 
   ret = nns_edge_data_create (&data_h);
@@ -2255,8 +2257,44 @@ TEST(edgeDataDeserialize, invalidParam03_n)
   ret = nns_edge_data_set_info (data_h, "temp-key", "temp-value");
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
-  ret = nns_edge_data_deserialize (data_h, NULL);
+  ret = nns_edge_data_serialize (data_h, &data, &data_len);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_deserialize (data_h, NULL, data_len);
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_destroy (data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  nns_edge_free (data);
+}
+
+/**
+ * @brief Deserialize edge-data - invalid param.
+ */
+TEST(edgeDataDeserialize, invalidParam04_n)
+{
+  nns_edge_data_h data_h;
+  void *data;
+  nns_size_t data_len;
+  int ret;
+
+  ret = nns_edge_data_create (&data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_set_info (data_h, "temp-key", "temp-value");
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_serialize (data_h, &data, &data_len);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_deserialize (data_h, data, 1U);
+  EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_data_destroy (data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  nns_edge_free (data);
 }
 
 /**


### PR DESCRIPTION
Code clean,
1. handle data size to deserailze edge data.
2. Fix typo and revise testcases.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>