### PR TITLE
[TizenRT] Remove object file when cleaning

### DIFF
--- a/tools/build_TizenRT/Makefile
+++ b/tools/build_TizenRT/Makefile
@@ -119,6 +119,7 @@ depend: .depend
 clean:
 	$(call DELFILE, .built)
 	$(call CLEAN)
+	$(Q) find . -name "*.o" -exec rm -rf {} \;
 
 distclean: clean
 	$(call DELFILE, Make.dep)


### PR DESCRIPTION
Remove object files that are the result of TizenRT build when cleaning.

Signed-off-by: gichan <gichan2.jang@samsung.com>