### PR TITLE
[Git] Add ignore list related with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,16 @@ debian/tmp/*
 .vs/
 bin/
 obj/
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
 This patch is to ignore cmake related files generated after the build.