### PR TITLE
[Test] fix memory leak

### DIFF
--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -2091,6 +2091,8 @@ TEST(edgeDataSerialize, normal)
 
   ret = nns_edge_data_destroy (dest_h);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  SAFE_FREE(serialized_data);
 }
 
 
@@ -3580,6 +3582,8 @@ TEST(edgeQueue, pushInvalidParam03_n)
   EXPECT_FALSE (nns_edge_queue_push (queue_h, data, 0U, NULL));
 
   EXPECT_TRUE (nns_edge_queue_destroy (queue_h));
+
+  SAFE_FREE(data);
 }
 
 /**


### PR DESCRIPTION
 When running the test, the memory is not released,
 fx the memory-leak by releasing the memory before the end of the test.