### PR TITLE
[Edge] Remove unnecessary pthread attribute.

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -765,7 +765,6 @@ static int
 _nns_edge_create_message_thread (nns_edge_handle_s * eh, nns_edge_conn_s * conn,
     int64_t client_id)
 {
-  pthread_attr_t attr;
   int status;
   nns_edge_thread_data_s *thread_data = NULL;
 
@@ -777,16 +776,12 @@ _nns_edge_create_message_thread (nns_edge_handle_s * eh, nns_edge_conn_s * conn,
   }
 
    /** Create message receving thread */
-  pthread_attr_init (&attr);
-  pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_JOINABLE);
-
   thread_data->eh = eh;
   thread_data->conn = conn;
   thread_data->client_id = client_id;
 
-  status = pthread_create (&conn->msg_thread, &attr, _nns_edge_message_handler,
+  status = pthread_create (&conn->msg_thread, NULL, _nns_edge_message_handler,
       thread_data);
-  pthread_attr_destroy (&attr);
 
   if (status != 0) {
     nns_edge_loge ("Failed to create message handler thread.");
@@ -883,14 +878,9 @@ _nns_edge_send_thread (void *thread_data)
 static int
 _nns_edge_create_send_thread (nns_edge_handle_s * eh)
 {
-  pthread_attr_t attr;
   int status;
 
-  pthread_attr_init (&attr);
-  pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_JOINABLE);
-
-  status = pthread_create (&eh->send_thread, &attr, _nns_edge_send_thread, eh);
-  pthread_attr_destroy (&attr);
+  status = pthread_create (&eh->send_thread, NULL, _nns_edge_send_thread, eh);
 
   if (status != 0) {
     nns_edge_loge ("Failed to create sender thread.");
@@ -1150,7 +1140,6 @@ _nns_edge_create_socket_listener (nns_edge_handle_s * eh)
   bool done = false;
   struct sockaddr_in saddr = { 0 };
   socklen_t saddr_len = sizeof (struct sockaddr_in);
-  pthread_attr_t attr;
   int status;
 
   if (!_fill_socket_addr (&saddr, eh->host, eh->port)) {
@@ -1174,11 +1163,8 @@ _nns_edge_create_socket_listener (nns_edge_handle_s * eh)
     goto error;
   }
 
-  pthread_attr_init (&attr);
-  pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_JOINABLE);
-  status = pthread_create (&eh->listener_thread, &attr,
+  status = pthread_create (&eh->listener_thread, NULL,
       _nns_edge_socket_listener_thread, eh);
-  pthread_attr_destroy (&attr);
 
   if (status != 0) {
     nns_edge_loge ("Failed to create listener thread.");


### PR DESCRIPTION
'JOINABLE' is the default atribute of the pthread, so remove the attribute.
 *note: Some TizenRT board don't support this option.