### PR TITLE
[Cmd] use fixed size in cmd struct

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -91,7 +91,7 @@ typedef enum
 typedef struct
 {
   uint32_t magic;
-  nns_edge_cmd_e cmd;
+  uint32_t cmd; /**< enum for query commands, see nns_edge_cmd_e. */
   int64_t client_id;
 
   /* memory info */


### PR DESCRIPTION
Internal fix to set fixed size of edge-cmd struct.