### PR TITLE
[bugfix] Change the range of valid port

### DIFF
--- a/include/nnstreamer-edge.h
+++ b/include/nnstreamer-edge.h
@@ -310,7 +310,7 @@ int nns_edge_is_connected (nns_edge_h edge_h);
  * ---------------------|--------------------------------------------------------------
  * CAPS or CAPABILITY   | capability strings.
  * IP or HOST           | IP address of the node to accept connection from other node.
- * PORT                 | Port of the node to accept connection from other node. The value should be 0 or higher.
+ * PORT                 | Port of the node to accept connection from other node. The value should be 0 or higher, if the port is set to 0 then the available port is allocated.
  * DEST_IP or DEST_HOST | IP address of the destination node. In case of TCP connection, it is the IP address of the destination node, and in the case of Hybrid or AITT connection, it is the IP address of the broker.
  * DEST_PORT            | Port of the destination node. In case of TCP connection, it is the port number of the destination node, and in the case of Hybrid or AITT connection, it is the port number of the broker. The value should be 0 or higher.
  * TOPIC                | Topic used to publish/subscribe to/from the broker.

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.c
@@ -149,6 +149,10 @@ nns_edge_parse_port_number (const char *port_str)
 
   port = (int) strtoll (port_str, NULL, 10);
 
+  if (port == 0) {
+    port = nns_edge_get_available_port ();
+  }
+
   if (!PORT_IS_VALID (port)) {
     nns_edge_loge ("Invalid port number %d.", port);
     port = -1;

--- a/tests/unittest_nnstreamer-edge-aitt.cc
+++ b/tests/unittest_nnstreamer-edge-aitt.cc
@@ -336,7 +336,7 @@ TEST(edgeAitt, connectInvalidParam4_n)
   ret = nns_edge_aitt_create (&handle);
   EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
 
-  ret = nns_edge_aitt_connect (handle, "temp-aitt-id", "temp-aitt-topic", "127.0.0.1", 0);
+  ret = nns_edge_aitt_connect (handle, "temp-aitt-id", "temp-aitt-topic", "127.0.0.1", -1);
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
 
   ret = nns_edge_aitt_close (handle);

--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -826,8 +826,6 @@ TEST(edge, setInfoInvalidParam08_n)
   /* Invalid port number */
   ret = nns_edge_set_info (edge_h, "port", "-1");
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
-  ret = nns_edge_set_info (edge_h, "port", "0");
-  EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
   ret = nns_edge_set_info (edge_h, "port", "77777");
   EXPECT_NE (ret, NNS_EDGE_ERROR_NONE);
 


### PR DESCRIPTION
    - set available port when user set port to '0'
    - ml service api set '0' as the default port if the port isn't set
      but '0' is an invalid port