### PR TITLE
[bugfix] Modify dlog output code

### DIFF
--- a/include/nnstreamer-edge.h
+++ b/include/nnstreamer-edge.h
@@ -75,18 +75,6 @@ typedef enum {
 } nns_edge_node_type_e;
 
 /**
- * @brief Enumeration for log message.
- */
-typedef enum {
-  NNS_EDGE_LOG_DEBUG = 0,
-  NNS_EDGE_LOG_INFO,
-  NNS_EDGE_LOG_WARNING,
-  NNS_EDGE_LOG_ERROR,
-  NNS_EDGE_LOG_FATAL,
-  NNS_EDGE_LOG_NONE
-} nns_edge_log_level_e;
-
-/**
  * @brief Callback for the nnstreamer edge event.
  * @note This callback will suspend data stream. Do not spend too much time in the callback.
  * @return User should return NNS_EDGE_ERROR_NONE if an event is successfully handled.
@@ -487,12 +475,6 @@ int nns_edge_data_get_info (nns_edge_data_h data_h, const char *key, char **valu
  * @retval #NNS_EDGE_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int nns_edge_data_clear_info (nns_edge_data_h data_h);
-
-/**
- * @brief Set the logging level. Default value is NNS_EDGE_LOG_INFO.
- * @param[in] level The log level to print out.
- */
-void nns_edge_set_log_level (nns_edge_log_level_e level);
 
 /**
  * @brief Get the version of nnstreamer-edge.

--- a/jni/nnstreamer-edge.mk
+++ b/jni/nnstreamer-edge.mk
@@ -13,7 +13,6 @@ NNSTREAMER_EDGE_SRCS := \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-data.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-event.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-internal.c \
-    $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-log.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-metadata.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-queue.c \
     $(NNSTREAMER_EDGE_ROOT)/src/libnnstreamer-edge/nnstreamer-edge-util.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,10 +4,12 @@ SET(NNS_EDGE_SRCS
     ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-data.c
     ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-event.c
     ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-internal.c
-    ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-log.c
     ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-util.c
     ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-queue.c
 )
+IF (NOT ENABLE_TIZEN)
+    SET(NNS_EDGE_SRCS ${NNS_EDGE_SRCS} ${NNS_EDGE_SRC_DIR}/nnstreamer-edge-log.c)
+ENDIF()
 
 IF(MQTT_SUPPORT)
     IF(MOSQUITTO_LIB)

--- a/src/libnnstreamer-edge/nnstreamer-edge-log.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-log.c
@@ -17,23 +17,6 @@
 #define DEBUG 0
 #endif
 
-#if defined(__TIZEN__)
-#include <dlog.h>
-
-#define _print_logd(...) dlog_print (DLOG_DEBUG, TAG_NAME, __VA_ARGS__)
-#define _print_logi(...) dlog_print (DLOG_INFO, TAG_NAME, __VA_ARGS__)
-#define _print_logw(...) dlog_print (DLOG_WARN, TAG_NAME, __VA_ARGS__)
-#define _print_loge(...) dlog_print (DLOG_ERROR, TAG_NAME, __VA_ARGS__)
-#define _print_logf(...) dlog_print (DLOG_FATAL, TAG_NAME, __VA_ARGS__)
-#elif defined(__ANDROID__)
-#include <android/log.h>
-
-#define _print_logd(...) __android_log_print (ANDROID_LOG_DEBUG, TAG_NAME, __VA_ARGS__)
-#define _print_logi(...) __android_log_print (ANDROID_LOG_INFO, TAG_NAME, __VA_ARGS__)
-#define _print_logw(...) __android_log_print (ANDROID_LOG_WARN, TAG_NAME, __VA_ARGS__)
-#define _print_loge(...) __android_log_print (ANDROID_LOG_ERROR, TAG_NAME, __VA_ARGS__)
-#define _print_logf(...) __android_log_print (ANDROID_LOG_FATAL, TAG_NAME, __VA_ARGS__)
-#else
 /**
  * @brief Internal util function to print log message.
  */
@@ -75,22 +58,6 @@ _ne_log_print (nns_edge_log_level_e level, const char *fmt, va_list args)
 #define _print_logw(...) _ne_log_print (NNS_EDGE_LOG_WARNING, __VA_ARGS__)
 #define _print_loge(...) _ne_log_print (NNS_EDGE_LOG_ERROR, __VA_ARGS__)
 #define _print_logf(...) _ne_log_print (NNS_EDGE_LOG_FATAL, __VA_ARGS__)
-#endif
-
-/**
- * @brief Internal logging level.
- */
-static nns_edge_log_level_e g_ne_log_level =
-    (DEBUG) ? NNS_EDGE_LOG_DEBUG : NNS_EDGE_LOG_INFO;
-
-/**
- * @brief Set the logging level.
- */
-void
-nns_edge_set_log_level (nns_edge_log_level_e level)
-{
-  g_ne_log_level = level;
-}
 
 /**
  * @brief Internal util function to print log message.
@@ -99,9 +66,6 @@ void
 nns_edge_print_log (nns_edge_log_level_e level, const char *fmt, ...)
 {
   va_list args;
-
-  if (level < g_ne_log_level)
-    return;
 
   va_start (args, fmt);
 

--- a/src/libnnstreamer-edge/nnstreamer-edge-log.h
+++ b/src/libnnstreamer-edge/nnstreamer-edge-log.h
@@ -22,6 +22,35 @@ extern "C" {
 
 #define TAG_NAME "nnstreamer-edge"
 
+#if defined(__TIZEN__)
+#include <dlog.h>
+
+#define nns_edge_logd(...) dlog_print (DLOG_DEBUG, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logi(...) dlog_print (DLOG_INFO, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logw(...) dlog_print (DLOG_WARN, TAG_NAME, __VA_ARGS__)
+#define nns_edge_loge(...) dlog_print (DLOG_ERROR, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logf(...) dlog_print (DLOG_FATAL, TAG_NAME, __VA_ARGS__)
+#elif defined(__ANDROID__)
+#include <android/log.h>
+
+#define nns_edge_logd(...) __android_log_print (ANDROID_LOG_DEBUG, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logi(...) __android_log_print (ANDROID_LOG_INFO, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logw(...) __android_log_print (ANDROID_LOG_WARN, TAG_NAME, __VA_ARGS__)
+#define nns_edge_loge(...) __android_log_print (ANDROID_LOG_ERROR, TAG_NAME, __VA_ARGS__)
+#define nns_edge_logf(...) __android_log_print (ANDROID_LOG_FATAL, TAG_NAME, __VA_ARGS__)
+#else
+/**
+ * @brief Enumeration for log message.
+ */
+typedef enum {
+  NNS_EDGE_LOG_DEBUG = 0,
+  NNS_EDGE_LOG_INFO,
+  NNS_EDGE_LOG_WARNING,
+  NNS_EDGE_LOG_ERROR,
+  NNS_EDGE_LOG_FATAL,
+  NNS_EDGE_LOG_NONE
+} nns_edge_log_level_e;
+
 /**
  * @brief Internal util function to print log message.
  */
@@ -32,7 +61,7 @@ void nns_edge_print_log (nns_edge_log_level_e level, const char *fmt, ...);
 #define nns_edge_loge(...) nns_edge_print_log (NNS_EDGE_LOG_ERROR, __VA_ARGS__)
 #define nns_edge_logd(...) nns_edge_print_log (NNS_EDGE_LOG_DEBUG, __VA_ARGS__)
 #define nns_edge_logf(...) nns_edge_print_log (NNS_EDGE_LOG_FATAL, __VA_ARGS__)
-
+#endif
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/libnnstreamer-edge/nnstreamer-edge-util.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-util.c
@@ -13,7 +13,7 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdarg.h>
-
+#include <inttypes.h>
 #include "nnstreamer-edge-log.h"
 #include "nnstreamer-edge-util.h"
 
@@ -174,7 +174,7 @@ nns_edge_malloc (nns_size_t size)
     mem = malloc (size);
 
   if (!mem)
-    nns_edge_loge ("Failed to allocate memory (%llu).", size);
+    nns_edge_loge ("Failed to allocate memory (%" PRIu64 ").", size);
 
   return mem;
 }


### PR DESCRIPTION
When outputting dlog using dlogutil in Tizen, garbage values are output in the format starting with %