### PR TITLE
Fix CMAKE_INSTALL_LIBDIR exampel in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ sudo systemctl start mosquitto
 ### Build and Run test
 ```
 # cd $NNST_EDGE_ROOT
-$ cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DENABLE_TEST=ON -DMQTT_SUPPORT=ON
+$ cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/lib -DENABLE_TEST=ON -DMQTT_SUPPORT=ON
 $ make -C build install
 
 # Run test


### PR DESCRIPTION
 In README, CMAKE_INSTALL_LIBDIR is set up with the "lib" path.
 The lib path is recorded in the pc file referenced by the pkg-config tool.
 This path must be modified to the absolute path "/lib".