### PR TITLE
github-action/gbs: Build nnstreamer-edge based all architecture

### DIFF
--- a/.github/workflows/tizen_integration_test.yml
+++ b/.github/workflows/tizen_integration_test.yml
@@ -9,6 +9,14 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        include:
+          - aarch: "-A x86_64"
+          - aarch: "-A i586"
+          - aarch: "-A armv7l"
+          - aarch: "-A aarch64"
+
     runs-on: ubuntu-20.04
 
     steps:
@@ -21,9 +29,12 @@ jobs:
     - name: configure GBS
       run: cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
     - name: run GBS
-      run: gbs build
+      run: gbs build ${{ matrix.aarch }}
     - name: get nnstreamer-main
       run: git clone https://github.com/nnstreamer/nnstreamer.git
     - name: run GBS on nnstreamer with unit test
-      run: pushd nnstreamer && gbs build --define "edge_test 1" && popd
+      run: |
+        pushd nnstreamer
+        gbs build ${{ matrix.aarch }} --define "edge_test 1"
+        popd
 ## @todo run nnstreamer-edge related test cases only


### PR DESCRIPTION
Current, gbs build system build nnstreamer-edge only in x86-64 architecture. 
This patch is to support to build x86_64, i586, armv7l aarch64 architecture