### PR TITLE
[Tizen] Fix gcov build error

### DIFF
--- a/packaging/nnstreamer-edge.spec
+++ b/packaging/nnstreamer-edge.spec
@@ -146,9 +146,9 @@ find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
 find . -name "CMakeCCompilerId*.gcda" -delete
 find . -name "CMakeCXXCompilerId*.gcda" -delete
 # Generate report
-lcov -t 'NNStreamer-edge unittest coverage' -o unittest.info -c -d . -b $(pwd) --no-external
+lcov -t 'NNStreamer-edge unittest coverage' -o unittest.info -c -d . -b $(pwd) --no-external --ignore-errors mismatch
 # Exclude test files.
-lcov -r unittest.info "*/tests/*" -o unittest-filtered.info
+lcov -r unittest.info "*/tests/*" -o unittest-filtered.info --ignore-errors graph,unused
 # Visualize the report
 genhtml -o result unittest-filtered.info -t "NNStreamer-edge %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
Due to the lcov 2.0 upgrade, the warning is changed to error so the gcov build fails. Ignore this case. (Tizen PM guide)