### PR TITLE
[Github] Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+---
+name: Issue report
+about: Create a report to help us improve
+
+---
+
+Having problems with a source code of a github repository?
+
+Having problems with the CI bot that controls the build process?
+
+Good to go? Then please remove these lines above, including this one, and help us understand your issue by answering the following:
+
+# Issue Description
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+Further Information
+===============
+* A link to an output result showing the issue
+* Exact OS version

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Having problems with a source code of a github repository?
+
+Having problems with the CI bot that controls the build process?
+
+Good to go? Then please remove these lines above, including this one, and help us understand your issue by answering the following:
+
+# Issue Description
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+Further Information
+===============
+* A link to an output result showing the issue
+* Exact OS version

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example, I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Support_request.md
+++ b/.github/ISSUE_TEMPLATE/Support_request.md
@@ -1,0 +1,13 @@
+---
+name: Support Request
+about: Report a problem with our project source code
+
+---
+
+![WARNING](https://media.giphy.com/media/Zsx8ZwmX3ajny/giphy.gif)
+
+Please only create issues/feature requests for the project here.
+
+For support contact our project maintainer(s), they meet online in a 'Issues' list.
+There you can ask questions if you have trouble understanding something, seek advice and mingle with other project members.
+For further information see 'Wiki' page.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+
+---
+# [Template] PR Description
+
+In general, github system automatically copies your commit message for your convenience.
+Please remove unused part of the template after writing your own PR description with this template.
+```bash
+$ git commit -s filename1 filename2 ... [enter]
+
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical;
+various tools like `log`, `shortlog` and `rebase` can get confused 
+if you run the two together.
+
+Further paragraphs come after blank lines.
+
+**Changes proposed in this PR:**
+- Bullet points are okay, too
+- Typically a hyphen or asterisk is used for the bullet, preceded
+  by a single space, with blank lines in between, but conventions vary here.
+
+Resolves: #123
+See also: #456, #789
+
+**Self evaluation:**
+1. Build test: [ ]Passed [ ]Failed [*]Skipped
+2. Run test: [ ]Passed [ ]Failed [*]Skipped
+
+**How to evaluate:**
+1. Describe how to evaluate in order to be reproduced by reviewer(s).
+
+Add signed-off message automatically by running **$git commit -s ...** command.
+
+$ git push origin <your_branch_name>
+```
+


### PR DESCRIPTION
 This PR is to create a templates to autemate issue and PR process.
 Issue and PR templates still use the format of the parent project, nnstreamer, for uniformity.
 (https://github.com/nnstreamer/nnstreamer/tree/main/.github)