### PR TITLE
[README] Change code coverage result repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Code Coverage](http://ci.nnstreamer.ai/nnstreamer-edge/ci/badge/codecoverage.svg)](http://ci.nnstreamer.ai/nnstreamer-edge/ci/gcov_html/index.html)
-[![DailyBuild](http://ci.nnstreamer.ai/nnstreamer-edge/ci/daily-build/badge/daily_build_badge.svg)](http://ci.nnstreamer.ai/nnstreamer-edge/ci/daily-build/build_result/)
+[![Code Coverage](https://nnstreamer.github.io/testresult/nnstreamer-edge/coverage_badge.svg)](https://nnstreamer.github.io/testresult/nnstreamer-edge/index.html)
 
 # nnstreamer-edge
 Remote source nodes for NNStreamer pipelines without GStreamer dependencies


### PR DESCRIPTION
Change code coverage result repo from TAOS-CI to github.io


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
