### PR TITLE
[Fix] accept a transfer that carries the maximum number of memories

### DIFF
--- a/src/libnnstreamer-edge/nnstreamer-edge-data.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-data.c
@@ -703,7 +703,7 @@ nns_edge_data_is_serialized (const void *data, const nns_size_t data_len)
 
   /**
    * @todo The number of memories in data.
-   * Total number of memories in edge-data should be less than NNS_EDGE_DATA_LIMIT.
+   * Total number of memories in edge-data should not exceed NNS_EDGE_DATA_LIMIT.
    * Fetch nns-edge version info and check allowed memories if NNS_EDGE_DATA_LIMIT is updated.
    */
   if (header->num_mem > NNS_EDGE_DATA_LIMIT) {

--- a/src/libnnstreamer-edge/nnstreamer-edge-internal.c
+++ b/src/libnnstreamer-edge/nnstreamer-edge-internal.c
@@ -435,11 +435,14 @@ _nns_edge_cmd_is_valid (nns_edge_cmd_s * cmd)
 
   /**
    * @todo The number of memories in data.
-   * Total number of memories in edge-data should be less than NNS_EDGE_DATA_LIMIT.
+   * Total number of memories in edge-data should not exceed NNS_EDGE_DATA_LIMIT.
    * Fetch nns-edge version info and check allowed memories if NNS_EDGE_DATA_LIMIT is updated.
    */
-  if (cmd->info.num > NNS_EDGE_DATA_LIMIT)
+  if (cmd->info.num > NNS_EDGE_DATA_LIMIT) {
+    nns_edge_loge ("Invalid command, the max memories for data transfer is %d.",
+        NNS_EDGE_DATA_LIMIT);
     return false;
+  }
 
   return true;
 }
@@ -586,11 +589,6 @@ _nns_edge_cmd_receive (nns_edge_conn_s * conn, nns_edge_cmd_s * cmd)
   }
 
   nns_edge_logd ("Received command:%d (num:%u)", cmd->info.cmd, cmd->info.num);
-  if (cmd->info.num >= NNS_EDGE_DATA_LIMIT) {
-    nns_edge_loge ("Invalid request, the max memories for data transfer is %d.",
-        NNS_EDGE_DATA_LIMIT);
-    return NNS_EDGE_ERROR_IO;
-  }
 
   if (!_nns_edge_cmd_size_is_valid (cmd, conn->max_transfer_size)) {
     nns_edge_loge

--- a/tests/unittest_nnstreamer-edge.cc
+++ b/tests/unittest_nnstreamer-edge.cc
@@ -7478,6 +7478,387 @@ TEST (edgeTransfer, sendWithinReceiverLimit)
 }
 
 /**
+ * @brief What a query or pub/sub pair saw while transferring data at the memory limit.
+ */
+typedef struct {
+  nns_edge_h handle; /**< Node to answer through, only used by the receiving server. */
+  bool is_server;
+  unsigned int received;
+  unsigned int closed;
+  unsigned int count;
+  bool payload_ok;
+  bool meta_ok;
+} ne_test_limit_data_s;
+
+/**
+ * @brief Edge event callback that checks every memory of a data event, and answers on the server side.
+ */
+static int
+_test_limit_data_cb (nns_edge_event_h event_h, void *user_data)
+{
+  ne_test_limit_data_s *_td = (ne_test_limit_data_s *) user_data;
+  nns_edge_event_e event = NNS_EDGE_EVENT_UNKNOWN;
+  nns_edge_data_h data_h;
+  void *data;
+  char *val = NULL;
+  nns_size_t len, expected_len, j;
+  unsigned int i, count;
+  int ret;
+
+  if (!_td || nns_edge_event_get_type (event_h, &event) != NNS_EDGE_ERROR_NONE)
+    return NNS_EDGE_ERROR_NONE;
+
+  switch (event) {
+    case NNS_EDGE_EVENT_NEW_DATA_RECEIVED:
+      ret = nns_edge_event_parse_new_data (event_h, &data_h);
+      EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+      ret = nns_edge_data_get_count (data_h, &count);
+      EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+      _td->count = count;
+      _td->payload_ok = true;
+
+      for (i = 0; i < count; i++) {
+        if (nns_edge_data_get (data_h, i, &data, &len) != NNS_EDGE_ERROR_NONE) {
+          _td->payload_ok = false;
+          break;
+        }
+
+        expected_len = (nns_size_t) (i % 16U) + 1U;
+        if (len != expected_len) {
+          _td->payload_ok = false;
+          break;
+        }
+
+        for (j = 0; j < len; j++) {
+          if (((uint8_t *) data)[j] != _test_peer_byte (i, j)) {
+            _td->payload_ok = false;
+            break;
+          }
+        }
+      }
+
+      _td->meta_ok = (nns_edge_data_get_info (data_h, "test-meta", &val) == NNS_EDGE_ERROR_NONE
+                      && val != NULL && 0 == strcmp (val, "from-peer"));
+      SAFE_FREE (val);
+
+      if (_td->is_server) {
+        ret = nns_edge_send (_td->handle, data_h);
+        EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+      }
+
+      nns_edge_data_destroy (data_h);
+      _td->received++;
+      break;
+    case NNS_EDGE_EVENT_CONNECTION_CLOSED:
+      _td->closed++;
+      break;
+    default:
+      break;
+  }
+
+  return NNS_EDGE_ERROR_NONE;
+}
+
+/**
+ * @brief Fill an edge data handle with NNS_EDGE_DATA_LIMIT memories of distinct content.
+ */
+static void
+_test_fill_limit_data (nns_edge_data_h data_h)
+{
+  void *mem;
+  nns_size_t len, j;
+  unsigned int i;
+  int ret;
+
+  for (i = 0; i < NNS_EDGE_DATA_LIMIT; i++) {
+    len = (nns_size_t) (i % 16U) + 1U;
+    mem = malloc (len);
+    ASSERT_TRUE (mem != NULL);
+
+    for (j = 0; j < len; j++)
+      ((uint8_t *) mem)[j] = _test_peer_byte (i, j);
+
+    ret = nns_edge_data_add (data_h, mem, len, nns_edge_free);
+    EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  }
+}
+
+/**
+ * @brief A data handle holding exactly the memory limit round-trips over a query pair.
+ */
+TEST (edgeTransfer, dataAtMemoryLimit)
+{
+  nns_edge_h server_h, client_h;
+  ne_test_limit_data_s rd_server, rd_client;
+  nns_edge_data_h data_h;
+  char *val;
+  unsigned int retry;
+  int ret, port;
+
+  memset (&rd_server, 0, sizeof (rd_server));
+  memset (&rd_client, 0, sizeof (rd_client));
+  port = nns_edge_get_available_port ();
+
+  val = nns_edge_strdup_printf ("%d", port);
+  ret = nns_edge_create_handle ("limit-mem-server", NNS_EDGE_CONNECT_TYPE_TCP,
+      NNS_EDGE_NODE_TYPE_QUERY_SERVER, &server_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  rd_server.handle = server_h;
+  rd_server.is_server = true;
+  nns_edge_set_event_callback (server_h, _test_limit_data_cb, &rd_server);
+  nns_edge_set_info (server_h, "IP", "127.0.0.1");
+  nns_edge_set_info (server_h, "PORT", val);
+  nns_edge_set_info (server_h, "CAPS", "test server");
+  SAFE_FREE (val);
+
+  ret = nns_edge_create_handle ("limit-mem-client", NNS_EDGE_CONNECT_TYPE_TCP,
+      NNS_EDGE_NODE_TYPE_QUERY_CLIENT, &client_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  nns_edge_set_event_callback (client_h, _test_limit_data_cb, &rd_client);
+  nns_edge_set_info (client_h, "IP", "127.0.0.1");
+  nns_edge_set_info (client_h, "CAPS", "test client");
+
+  ret = nns_edge_start (server_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_start (client_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  usleep (200000);
+  ret = nns_edge_connect (client_h, "127.0.0.1", port);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  usleep (200000);
+
+  ret = nns_edge_data_create (&data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  _test_fill_limit_data (data_h);
+  ret = nns_edge_data_set_info (data_h, "test-meta", "from-peer");
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_send (client_h, data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  retry = 0U;
+  do {
+    usleep (100000);
+    if (rd_server.received > 0)
+      break;
+  } while (retry++ < 50U);
+
+  EXPECT_EQ (rd_server.received, 1U);
+  EXPECT_EQ (rd_server.closed, 0U);
+  EXPECT_EQ (rd_server.count, (unsigned int) NNS_EDGE_DATA_LIMIT);
+  EXPECT_TRUE (rd_server.payload_ok);
+  EXPECT_TRUE (rd_server.meta_ok);
+
+  retry = 0U;
+  do {
+    usleep (100000);
+    if (rd_client.received > 0)
+      break;
+  } while (retry++ < 50U);
+
+  EXPECT_EQ (rd_client.received, 1U);
+  EXPECT_EQ (rd_client.closed, 0U);
+  EXPECT_EQ (rd_client.count, (unsigned int) NNS_EDGE_DATA_LIMIT);
+  EXPECT_TRUE (rd_client.payload_ok);
+  EXPECT_TRUE (rd_client.meta_ok);
+
+  ret = nns_edge_data_destroy (data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (client_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (server_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+}
+
+/**
+ * @brief The same transfer broadcasts intact from a publisher to a subscriber.
+ */
+TEST (edgeTransfer, dataAtMemoryLimitPubSub)
+{
+  nns_edge_h pub_h, sub_h;
+  ne_test_limit_data_s rd_sub;
+  nns_edge_data_h data_h;
+  char *val;
+  unsigned int retry;
+  int ret, port;
+
+  memset (&rd_sub, 0, sizeof (rd_sub));
+  port = nns_edge_get_available_port ();
+
+  val = nns_edge_strdup_printf ("%d", port);
+  ret = nns_edge_create_handle (
+      "limit-pub", NNS_EDGE_CONNECT_TYPE_TCP, NNS_EDGE_NODE_TYPE_PUB, &pub_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  nns_edge_set_info (pub_h, "IP", "127.0.0.1");
+  nns_edge_set_info (pub_h, "PORT", val);
+  nns_edge_set_info (pub_h, "CAPS", "test pub");
+  SAFE_FREE (val);
+
+  ret = nns_edge_create_handle (
+      "limit-sub", NNS_EDGE_CONNECT_TYPE_TCP, NNS_EDGE_NODE_TYPE_SUB, &sub_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  nns_edge_set_event_callback (sub_h, _test_limit_data_cb, &rd_sub);
+  nns_edge_set_info (sub_h, "IP", "127.0.0.1");
+  nns_edge_set_info (sub_h, "CAPS", "test sub");
+
+  ret = nns_edge_start (pub_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_start (sub_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  usleep (200000);
+  ret = nns_edge_connect (sub_h, "127.0.0.1", port);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  usleep (200000);
+
+  ret = nns_edge_data_create (&data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  _test_fill_limit_data (data_h);
+  ret = nns_edge_data_set_info (data_h, "test-meta", "from-peer");
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  ret = nns_edge_send (pub_h, data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  retry = 0U;
+  do {
+    usleep (100000);
+    if (rd_sub.received > 0)
+      break;
+  } while (retry++ < 50U);
+
+  EXPECT_EQ (rd_sub.received, 1U);
+  EXPECT_EQ (rd_sub.closed, 0U);
+  EXPECT_EQ (rd_sub.count, (unsigned int) NNS_EDGE_DATA_LIMIT);
+  EXPECT_TRUE (rd_sub.payload_ok);
+  EXPECT_TRUE (rd_sub.meta_ok);
+
+  ret = nns_edge_data_destroy (data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (sub_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (pub_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+}
+
+/**
+ * @brief One memory over the limit is refused, pinning the bound that keeps cmd->mem[] in range.
+ */
+TEST (edgeTransfer, dataOverMemoryLimit_n)
+{
+  ne_test_peer_s peer;
+  ne_test_recv_s rd;
+  nns_edge_h edge_h;
+  int ret;
+
+  memset (&peer, 0, sizeof (peer));
+  memset (&rd, 0, sizeof (rd));
+  peer.port = nns_edge_get_available_port ();
+  peer.send_data = true;
+  peer.num = NNS_EDGE_DATA_LIMIT + 1;
+  ASSERT_TRUE (_test_peer_start (&peer));
+
+  edge_h = _test_sub_create ("sub-mem-over", &rd, NULL);
+  ASSERT_TRUE (edge_h != NULL);
+
+  ret = nns_edge_start (edge_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_connect (edge_h, "127.0.0.1", peer.port);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  _test_wait_event (&rd);
+
+  EXPECT_EQ (rd.received, 0U);
+  EXPECT_EQ (rd.closed, 1U);
+
+  _test_peer_stop (&peer);
+  EXPECT_TRUE (peer.sent_data);
+
+  ret = nns_edge_release_handle (edge_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  SAFE_FREE (rd.meta_value);
+}
+
+/**
+ * @brief Accepting the memory limit does not relax the byte-size limit of the receiver.
+ */
+TEST (edgeTransfer, dataAtMemoryLimitOverSize_n)
+{
+  nns_edge_h server_h, client_h;
+  ne_test_recv_s rd_server, rd_client;
+  nns_edge_data_h data_h;
+  void *data;
+  char *val;
+  unsigned int i;
+  int ret, port;
+
+  memset (&rd_server, 0, sizeof (rd_server));
+  memset (&rd_client, 0, sizeof (rd_client));
+  port = nns_edge_get_available_port ();
+
+  val = nns_edge_strdup_printf ("%d", port);
+  ret = nns_edge_create_handle ("limit-size-server", NNS_EDGE_CONNECT_TYPE_TCP,
+      NNS_EDGE_NODE_TYPE_QUERY_SERVER, &server_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  nns_edge_set_event_callback (server_h, _test_recv_event_cb, &rd_server);
+  nns_edge_set_info (server_h, "IP", "127.0.0.1");
+  nns_edge_set_info (server_h, "PORT", val);
+  nns_edge_set_info (server_h, "CAPS", "test server");
+  ret = nns_edge_set_info (server_h, "MAX_TRANSFER_SIZE", "1024");
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  SAFE_FREE (val);
+
+  ret = nns_edge_create_handle ("limit-size-client", NNS_EDGE_CONNECT_TYPE_TCP,
+      NNS_EDGE_NODE_TYPE_QUERY_CLIENT, &client_h);
+  ASSERT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  nns_edge_set_event_callback (client_h, _test_recv_event_cb, &rd_client);
+  nns_edge_set_info (client_h, "IP", "127.0.0.1");
+  nns_edge_set_info (client_h, "CAPS", "test client");
+
+  ret = nns_edge_start (server_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_start (client_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  usleep (200000);
+  ret = nns_edge_connect (client_h, "127.0.0.1", port);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  usleep (200000);
+
+  ret = nns_edge_data_create (&data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  for (i = 0; i < NNS_EDGE_DATA_LIMIT; i++) {
+    data = calloc (1, 16U);
+    ASSERT_TRUE (data != NULL);
+    ret = nns_edge_data_add (data_h, data, 16U, nns_edge_free);
+    EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  }
+
+  /* The sender is not limited, so the send itself succeeds. */
+  ret = nns_edge_send (client_h, data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  _test_wait_event (&rd_server);
+
+  EXPECT_EQ (rd_server.received, 0U);
+  EXPECT_EQ (rd_server.closed, 1U);
+
+  ret = nns_edge_data_destroy (data_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (client_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+  ret = nns_edge_release_handle (server_h);
+  EXPECT_EQ (ret, NNS_EDGE_ERROR_NONE);
+
+  SAFE_FREE (rd_server.meta_value);
+  SAFE_FREE (rd_client.meta_value);
+}
+
+/**
  * @brief A node that announces a transfer and then goes quiet loses the connection.
  */
 TEST (edgeTransfer, recvTimeoutOnSilentPeer_n)


### PR DESCRIPTION
Item **A4** of #259.

## Problem

An edge data handle holds up to `NNS_EDGE_DATA_LIMIT` (256) memories: `nns_edge_data_add()` refuses only the 257th, and the sender's `_nns_edge_cmd_is_valid()` rejects only `num > NNS_EDGE_DATA_LIMIT`. The receiver ran that same check and then an extra one in `_nns_edge_cmd_receive()`:

```c
if (cmd->info.num >= NNS_EDGE_DATA_LIMIT) {
  nns_edge_loge ("Invalid request, the max memories for data transfer is %d.", ...);
  return NNS_EDGE_ERROR_IO;
}
```

So a transfer of exactly 256 memories went out and was then refused on arrival. #259 describes this as the transfer being dropped, but the result is worse: the refusal is a receive error, and `_nns_edge_message_handler()` handles a receive error with `remove_connection = true`. The receiver **closes the connection** (`NNS_EDGE_EVENT_CONNECTION_CLOSED`), so the peer loses its link, not just one message.

This can happen in normal use. nnstreamer's `NNS_TENSOR_SIZE_LIMIT` is also 256, and both `tensor_query_client` / `tensor_query_server` and `edgesink` add one memory per tensor (`gst_tensor_buffer_get_count()` + `gst_tensor_buffer_get_nth_memory()`). A buffer that uses the full tensor count therefore triggers the bug.

## Change

- `_nns_edge_cmd_receive()`: remove the extra `>=` check, so `_nns_edge_cmd_is_valid()` is the only rule on both ends. That rule still keeps `num` within `cmd->mem[]` and `cmd->info.mem_size[]` (both have `NNS_EDGE_DATA_LIMIT` entries), so the upper bound the receiver needs is unchanged.
- `_nns_edge_cmd_is_valid()`: when it refuses a command, it now logs the limit, as the removed check did, so the diagnostic is kept.
- Comment wording: the `@todo` above that check and its copy in `nns_edge_data_deserialize()` said "less than the limit", which describes the removed check, not the code. Both now say "not exceed". This is the only change in `nnstreamer-edge-data.c`.

There is no API or wire-format change, and the diff touches 2 source files (+6/−8).

**Compatibility:** a receiver built before this change still refuses 256 memories from a newer sender. The sending side cannot fix that, and this PR does not change it.

## Tests

Added after `edgeTransfer.sendWithinReceiverLimit` in `tests/unittest_nnstreamer-edge.cc`:

| Test | What it checks |
|---|---|
| `edgeTransfer.dataAtMemoryLimit` | Query client → server → client round trip with 256 memories. Memory *i* has its own length and contents, plus metadata. Both ends must receive all 256 intact and no `CONNECTION_CLOSED`. |
| `edgeTransfer.dataAtMemoryLimitPubSub` | The same payload over PUB → SUB, which covers the broadcast send path. |
| `edgeTransfer.dataOverMemoryLimit_n` | A scripted peer announces 257. The subscriber must refuse it and close. This fixes the upper bound in place, so A4 cannot be "fixed" by accepting 257, which would overflow `cmd->mem[]`. |
| `edgeTransfer.dataAtMemoryLimitOverSize_n` | 256 × 16-byte memories against `MAX_TRANSFER_SIZE=1024`. The server must receive nothing and close, showing that accepting 256 memories does not bypass the byte limit from #267. |

`edgeData.addMaxData_n` already covers the sender-side rule that the 257th `nns_edge_data_add()` fails.

## Verification (local, WSL, gcc)

- **Fails without the fix:** with `nnstreamer-edge-internal.c` / `nnstreamer-edge-data.c` reverted to `main` and the new tests kept, `dataAtMemoryLimit` and `dataAtMemoryLimitPubSub` fail. The receiver closes the connection instead of delivering the data. The two `_n` tests pass there, as expected, because they test rules this PR does not change.
- **Full ctest:** passes under AddressSanitizer and in a plain build (3/3 binaries). `unittest_nnstreamer-edge-custom` passes 33/33.
- **Flakiness:** the new tests pass `--gtest_repeat=30` under ASan and plain builds with no failures. They take about 0.6 s, 0.5 s, 0.12 s and 0.53 s.
- **ThreadSanitizer:** the new tests pass with `--gtest_repeat=5`. The only reports are the known `conn->running` races (A5 of #259), not the changed code or the new test callback.
- **Static checks:** clang-format 16 produces no diff for the test file. GNU indent reports nothing in the changed hunks. doxygen-tag reports nothing new against `main`.
- **Not verified locally:** `unittest_nnstreamer-edge-mqtt` was not built because there is no broker locally. This change does not touch the MQTT path, since `nns_edge_data_deserialize()` already accepted 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
